### PR TITLE
Relax node engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "server-local": "nodemon ./src/server/server"
   },
   "engines": {
-    "node": "12.19.0"
+    "node": "^12.19.0"
   },
   "dependencies": {
     "axios": "^0.21.0",


### PR DESCRIPTION
The node engine is set to a very specific version, which forces users to install and use it. Unless the project needs that specific version for a reason, I suggest to _relax_ it and only set the minimum requirement.